### PR TITLE
Bugfix: production readiness for modulized version

### DIFF
--- a/minitwit.py
+++ b/minitwit.py
@@ -446,14 +446,13 @@ app.jinja_env.filters['datetimeformat'] = format_datetime
 app.jinja_env.filters['gravatar'] = gravatar_url
 #pylint: enable=no-member
 
-if __name__ == '__main__':
-    # Model: https://gist.github.com/rtzll/8f0f7668c4ca9813e9380b45b932e7c2
-    # https://stackoverflow.com/questions/11994325/how-to-divide-flask-app-into-multiple-py-files
-    app.register_blueprint(healthcheck_api)
-    app.register_blueprint(admin_api)
+# Model: https://gist.github.com/rtzll/8f0f7668c4ca9813e9380b45b932e7c2
+# https://stackoverflow.com/questions/11994325/how-to-divide-flask-app-into-multiple-py-files
+app.register_blueprint(healthcheck_api)
+app.register_blueprint(admin_api)
 
-    # So we know the available endpoints to be able to call
-    ConfigService.log_available_endpoints(app)
+# So we know the available endpoints to be able to call
+ConfigService.log_available_endpoints(app)
 
-    # flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload
-    server = app.run(host='0.0.0.0', threaded=True, debug=False, use_reloader=False)
+# flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload
+# server = app.run(host='0.0.0.0', threaded=True, debug=False, use_reloader=False)

--- a/minitwit.py
+++ b/minitwit.py
@@ -119,7 +119,7 @@ def get_db_credentials():
     app.logger.info('%s=%s', CONFIG_DB_SECRET_ARN, secret_arn) #pylint: disable=no-member
 
     # just making sure it's in AWS
-    region = "" if not HostService.is_running_in_the_cloud(app) else app.config['IN_CLOUD']["metadata"]["region"]
+    region = "" if not HostService.is_running_in_the_cloud(app) else app.config["IN_CLOUD"]["metadata"]["region"]
 
     try:
         client = boto3.client(

--- a/run-app
+++ b/run-app
@@ -13,4 +13,4 @@ if [ ! -f ${DB_DIR}/minitwit.db ] || [ -n "${INIT_DB}" ]; then
   ./init-db
 fi
 
-python ${FLASK_APP}
+flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload

--- a/viasat/platform/cloud/config_service.py
+++ b/viasat/platform/cloud/config_service.py
@@ -9,7 +9,7 @@ class ConfigService:
     """Implements host discovery capabilities"""
 
     @staticmethod
-    def log_current_environment(app):
+    def __log_current_environment(app):
         # Just log the current env as bootstrap record
         env_key_values = "\n"
         for k, v in os.environ.items():
@@ -28,8 +28,10 @@ class ConfigService:
     @staticmethod
     def bootstrap_cloud_metadata(app):
         """
-        Loads the metadata about the service just for information
+        Loads the metadata about the service just for information, printing the env info
         """
+        ConfigService.__log_current_environment(app)
+
         app.logger.info("Bootstrapping app server...")
 
         # Fetch the first information, which will force to check the cloud

--- a/viasat/platform/cloud/config_service.py
+++ b/viasat/platform/cloud/config_service.py
@@ -1,5 +1,6 @@
 import json
 import os
+import requests
 
 from viasat.platform.cloud.host_service import HostService
 

--- a/viasat/platform/observability/healthcheck_routes.py
+++ b/viasat/platform/observability/healthcheck_routes.py
@@ -47,6 +47,11 @@ def admin_readiness_healthcheck():
         readiness_check["overall"] = status
 
     else:
+        # Fix https://stackoverflow.com/questions/40377662/boto3-client-noregionerror-you-must-specify-a-region-error-only-sometimes/56131018#56131018
+        # raise NoRegionError() botocore.exceptions.NoRegionError: You must specify a region
+        # As the in cloud config has the metadata, we can use the default region where the apps is running
+        os.environ['AWS_DEFAULT_REGION'] = app.config["IN_CLOUD"]["metadata"]["region"]
+
         # Create an RDS client
         rds = boto3.client('rds')
 


### PR DESCRIPTION
# 🐛 Production Readiness Bugfixes

* Missing imports from different modules
* Add missing print on bootstrap vars module
* Make sure blueprints are registered when running from EC2 
  * app-run in docker image was working
* Add default values expected by the boto to call RDS
  * It also expected a permission

## 🔉 Error: No credentials == Lack of Permissions from EC2

```console
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]: [2023-03-09 10:17:36,041] ERROR in app: Exception on /healthcheck/readiness [GET]
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]: Traceback (most recent call last):
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2528, in wsgi_app
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     response = self.full_dispatch_request()
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1825, in full_dispatch_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     rv = self.handle_user_exception(e)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1823, in full_dispatch_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     rv = self.dispatch_request()
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1799, in dispatch_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/opt/minitwit/viasat/platform/observability/healthcheck_routes.py", line 59, in admin_readiness_healthcheck
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     response = rds.describe_db_instances()
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 530, in _api_call
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self._make_api_call(operation_name, kwargs)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 943, in _make_api_call
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     http, parsed_response = self._make_request(
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 966, in _make_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self._endpoint.make_request(operation_model, request_dict)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 119, in make_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self._send_request(request_dict, operation_model)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 198, in _send_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     request = self.create_request(request_dict, operation_model)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/endpoint.py", line 134, in create_request
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     self._event_emitter.emit(
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 412, in emit
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self._emitter.emit(aliased_event_name, **kwargs)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 256, in emit
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self._emit(event_name, kwargs)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/hooks.py", line 239, in _emit
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     response = handler(**kwargs)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/signers.py", line 105, in handler
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     return self.sign(operation_name, request)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/signers.py", line 189, in sign
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     auth.add_auth(request)
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:   File "/usr/local/lib/python3.8/dist-packages/botocore/auth.py", line 418, in add_auth
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]:     raise NoCredentialsError()
Mar 09 10:17:36 ip-10-105-238-77 flask[42887]: botocore.exceptions.NoCredentialsError: Unable to locate credentials
```

## 🔊 Error: NoRegionError()

* Missing the default region to be set

```console
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 485, in _get_client_args
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     return args_creator.get_client_args(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/args.py", line 92, in get_client_args
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     final_args = self.compute_client_args(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/args.py", line 205, in compute_client_args
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     endpoint_config = self._compute_endpoint_config(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/args.py", line 313, in _compute_endpoint_config
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     return self._resolve_endpoint(**resolve_endpoint_kwargs)
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/args.py", line 418, in _resolve_endpoint
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     return endpoint_bridge.resolve(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/client.py", line 590, in resolve
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     resolved = self.endpoint_resolver.construct_endpoint(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/regions.py", line 229, in construct_endpoint
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     result = self._endpoint_for_partition(
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:   File "/usr/local/lib/python3.8/dist-packages/botocore/regions.py", line 277, in _endpoint_for_partition
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]:     raise NoRegionError()
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]: botocore.exceptions.NoRegionError: You must specify a region.
Mar 09 10:06:40 ip-10-105-238-6 flask[90068]: 10.105.238.68 - - [09/Mar/2023 10:06:40] "GET /healthcheck/readiness HTTP/1.1" 500 -
Mar 09 10:06:41 ip-10-105-238-6 flask[90068]: 10.105.238.5 - - [09/Mar/2023 10:06:41] "GET /public HTTP/1.1" 200 -
Mar 09 10:06:45 ip-10-105-238-6 flask[90068]: 10.105.238.68 - - [09/Mar/2023 10:06:45] "GET /public HTTP/1.1" 200 -
```

# 🔏 RDS READ ONLY Permission Required

* To call the healthcheck, we need the minimum

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "rds:Describe*",
                "rds:ListTagsForResource",
                "ec2:DescribeAccountAttributes",
                "ec2:DescribeAvailabilityZones",
                "ec2:DescribeInternetGateways",
                "ec2:DescribeSecurityGroups",
                "ec2:DescribeSubnets",
                "ec2:DescribeVpcAttribute",
                "ec2:DescribeVpcs"
            ],
            "Resource": "*"
        },
        {
            "Effect": "Allow",
            "Action": [
                "cloudwatch:GetMetricStatistics",
                "logs:DescribeLogStreams",
                "logs:GetLogEvents",
                "devops-guru:GetResourceCollection"
            ],
            "Resource": "*"
        }
    ]
}
```