### PR TITLE
hotfix: resolve hostname from actuator causes HTTP 500 in private zone

### DIFF
--- a/viasat/platform/cloud/host_service.py
+++ b/viasat/platform/cloud/host_service.py
@@ -8,6 +8,20 @@ class HostService:
     """Implements host discovery capabilities"""
 
     @staticmethod
+    def __make_single_request(url):
+        session = requests.Session()
+        # https://stackoverflow.com/questions/15431044/can-i-set-max-retries-for-requests-request/15431343#15431343
+        retries = HTTPAdapter(max_retries=1)
+        session.mount('http://', retries)
+
+        # Making sure we timeout very quickly for the single request
+        # https://requests.readthedocs.io/en/stable/user/advanced/#timeouts
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+        response = session.get(url, timeout=1)
+        return response
+
+
+    @staticmethod
     def is_running_in_the_cloud(app):
         """
         :return: Whether we are running in EC2 by checking if there's connectivity to the IP address
@@ -24,26 +38,18 @@ class HostService:
             "type": "local"
         }
         try:
-            # We create a requests.Session() object and mount an HTTPAdapter() object with a max_retries value of 0.
-            # This ensures that the requests.get() function will not retry in case of a connection error or a timeout.
-            session = requests.Session()
-            # https://stackoverflow.com/questions/15431044/can-i-set-max-retries-for-requests-request/15431343#15431343
-            retries = HTTPAdapter(max_retries=1)
-            session.mount('http://', retries)
-
-            # Making sure we timeout very quickly for the single request
-            # https://requests.readthedocs.io/en/stable/user/advanced/#timeouts
-            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            response = session.get('http://169.254.169.254/latest/meta-data/', timeout=1)
+            response = HostService.__make_single_request('http://169.254.169.254/latest/meta-data/')
             app.config['IN_CLOUD']["status"] = response.status_code == 200
             app.config['IN_CLOUD']["type"] = "ec2" if response.status_code == 200 else "compute"
             app.logger.info("Running in the Cloud...")
 
         except (RequestException, TimeoutError, ConnectionError):
-            app.logger.info("Not running in the Cloud...")
+            # Just to repeat the metadata section
+            app.config['IN_CLOUD']["metadata"]: {}
 
         # Just return the cached value
         return app.config['IN_CLOUD']["status"]
+
 
     @staticmethod
     def get_hostname(app):
@@ -51,11 +57,39 @@ class HostService:
         :return: the hostname where the app is running: from EC2 is the public host or os hostname otherwise
         """
         # just make sure we have if we are on EC2 to show the public host for completeness
-        if HostService.is_running_in_the_cloud(app):
-            # Just get the public hostname from the metadata
-            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            return requests.get('http://169.254.169.254/latest/meta-data/public-hostname').text
+        if not HostService.is_running_in_the_cloud(app):
+            # By default, just return the nodename
+            # https://stackoverflow.com/questions/4271740/how-can-i-use-python-to-get-the-system-hostname/49610911#49610911
+            return os.uname().nodename.strip()
 
-        # By default, just return the nodename
-        # https://stackoverflow.com/questions/4271740/how-can-i-use-python-to-get-the-system-hostname/49610911#49610911
-        return os.uname().nodename
+        # Just get the public hostname from the metadata
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+        hostname = ""
+
+        # Start by digging the public URL. The code was initially failing when moving the app
+        # From the public to the private zone. The http response returned a 404 http error, resolved into a multi-space
+        # The exception was from setting this hostname to the HTTP response header
+        # "ValueError: Detected newline in header value.  This is a potential security problem"
+        aws_api_url = "http://169.254.169.254/latest/meta-data"
+        response = HostService.__make_single_request(aws_api_url + '/public-hostname')
+        if response.status_code == 200:
+            hostname = response.text
+            app.logger.info("We are running at the public zone at %s", hostname)
+
+        # If not, let's try the private, as chances are we are here...
+        response = HostService.__make_single_request(aws_api_url + '/local-hostname')
+        if response.status_code == 200:
+            hostname = response.text
+            app.logger.info("We are running at the private zone at %s", hostname)
+
+        else:
+            hostname = os.uname().nodename
+            app.logger.info("Can't determine the hostname for the app... getting local hostname %s", hostname)
+
+        # Return the value computed in the public
+        hostname = hostname.strip()
+        if len(hostname) == 0:
+            app.logger.warning("Can't determine the hostname. Setting as undetermined!")
+            hostname = "unknown"
+
+        return hostname

--- a/viasat/platform/core/http_response_decorator.py
+++ b/viasat/platform/core/http_response_decorator.py
@@ -9,6 +9,7 @@ class HttpResponseDecorator:
         if app.config['IN_CLOUD']["status"]:
             response.headers['X-Host-AZ'] = app.config['IN_CLOUD']["metadata"]["availabilityZone"]
 
+
     @staticmethod
     def decorate_with_app_info(app, response):
         # When deployed, Ansible will create the following properties:

--- a/viasat/platform/observability/healthcheck_routes.py
+++ b/viasat/platform/observability/healthcheck_routes.py
@@ -15,7 +15,6 @@ def admin_liveness_healthcheck():
     """
     :return: Show-casing plain text HTTP response for single liveliness, or liveness, health check
     """
-    app.logger.info("App successfully listening on port ")
     return "Ok", 200, {'content-type': 'text/plain'}
 
 


### PR DESCRIPTION
# 🐛 Hotfix:Load balancer failing with 500 and couldn't recover when placing them in the `private zone`
  
After got access to the private node, I was able to see the following error logs...

<img width="1396" alt="Screenshot 2023-03-09 at 7 10 15 PM" src="https://user-images.githubusercontent.com/131457/224215223-ab997b5b-42a5-432a-833a-16681bd223bd.png">

* References
  * https://aws.amazon.com/premiumsupport/knowledge-center/elb-fix-failing-health-checks-alb/ 
  * https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
  * https://docs.aws.amazon.com/autoscaling/ec2/userguide/us-iam-role.html
  * https://www.youtube.com/watch?v=zXSiPmBgQZQ
  * https://aws.amazon.com/builders-library/implementing-health-checks/
  * https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units


The solution was posted on the commit 27eeee9596369efd1b1d2921e9698b8539f94284

> **NOTE** This was introduced to resolve the hostname.

```console
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo journalctl -u minitwit -n 1000
-- Logs begin at Mon 2023-03-06 18:09:33 UTC, end at Fri 2023-03-10 01:38:09 UTC. --
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/werkzeug/datastructures.py", line 1153, in set
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     self._validate_value(_value)
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/werkzeug/datastructures.py", line 1117, in _validate_value
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     raise ValueError(
Mar 10 01:27:38 ip-10-105-238-214 flask[515]: ValueError: Detected newline in header value.  This is a potential security problem
Mar 10 01:27:38 ip-10-105-238-214 flask[515]: [2023-03-10 01:27:38,977] ERROR in app: Request finalizing failed with an error while handling an error
Mar 10 01:27:38 ip-10-105-238-214 flask[515]: Traceback (most recent call last):
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2528, in wsgi_app
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     response = self.full_dispatch_request()
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1826, in full_dispatch_request
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     return self.finalize_request(rv)
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1847, in finalize_request
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     response = self.process_response(response)
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 2340, in process_response
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     response = self.ensure_sync(func)(response)
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/opt/minitwit/minitwit.py", line 269, in add_header
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     HttpResponseDecorator.decorate_with_host_info(app, response)
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/opt/minitwit/viasat/platform/core/http_response_decorator.py", line 8, in decorate_with_host_info
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     response.headers['Host'] = app.config['HOSTNAME']
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:   File "/usr/local/lib/python3.8/dist-packages/werkzeug/datastructures.py", line 1236, in __setitem__
Mar 10 01:27:38 ip-10-105-238-214 flask[515]:     self.set(key, value)
```

# 🤔 Problem

* The introduced code was to resolve the hostname by calling the URL `169` from AWS.
  * The `public endpoint` was used and so it broke in the `private zone`
  * The solution is to handle all cases and make sure the HEADER is not set with a string that contains spaces.

# 🦶 Steps to fix

* Added Security group CIDR from the private as an ingress

# 📍 Allow ssh from public nodes to private nodes

* Add the CIDR of the private IP `10.105.238.0/24`... Or trying to use the "instances" ingress itself
* Add INGRESS from the "instances" themselves 
  * `Protocol: tcp, Port:   22, Source: sg-0e53354b2c7d2e702/no-access-sg`
* Add EGRESS from the "instances" to themselves
  * `Protocol: tcp, Port:   22, Destination: sg-0e53354b2c7d2e702/no-access-sg`

The checker failed, as expected!

```console
The "instances" security group inbound rules are incorrect.
  The rules are:
    Protocol: tcp, Port:   22, Source: 8.37.96.0/20
    Protocol: tcp, Port:   22, Source: 54.189.230.250/32
    Protocol: tcp, Port:   22, Source: sg-0e53354b2c7d2e702/no-access-sg
    Protocol: tcp, Port: 5000, Source: 8.37.96.0/20
    Protocol: tcp, Port: 5000, Source: sg-031864b21419ad48a/alb-sg
The "no-access-sg" security group outbound rules are incorrect.
  The rules are:
    Protocol: tcp, Port:   80, Destination: 0.0.0.0/0
    Protocol: tcp, Port:   22, Destination: sg-0e53354b2c7d2e702/no-access-sg
    Protocol: udp, Port:   53, Destination: 0.0.0.0/0
    Protocol: tcp, Port: 3306, Destination: sg-022a19aae28b55ecf/db-sg
    Protocol: tcp, Port:  443, Destination: 0.0.0.0/0
```

## `SOLUTION`: After that, I was able to SSH from the public node to the private by copying the key.pem to the node in the public zone in order to ssh to the private one.

# 🚧 Steps to solve after the network setup

* Got into the private EC2 host from one in the public zone
  * Bastion: orcas
  * Public: `52.21.148.181`, private ip `10.105.238.77`
  * Private:`10.105.238.214`

## 🥅 From Bastion -> Public Node -> Private Node

```console
mdesales@orcas:~$ ssh -i key.pem ubuntu@52.21.148.181
ubuntu@ip-10-105-238-77:~$ ssh -i key.pem ubuntu@10.105.238.214
Welcome to Ubuntu 20.04.5 LTS (GNU/Linux 5.15.0-1031-aws x86_64)
...
...

Last login: Fri Mar 10 00:37:11 2023 from 10.105.238.77
ubuntu@ip-10-105-238-214:~$ cd /opt/minitwit/
```

## 🕵️‍♀️  Fetch the patch that fixed the issue

* Just fetched the latest code in production
  * 27eeee9596369efd1b1d2921e9698b8539f94284

```console
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo su
root@ip-10-105-238-214:/opt/minitwit# git fetch
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (1/1), 680 bytes | 680.00 KiB/s, done.
From https://github.com/marcellodesales/minitwit
   4835d2b..27eeee9  master     -> origin/master
root@ip-10-105-238-214:/opt/minitwit# git checkout master
Switched to branch 'master'
Your branch is behind 'origin/master' by 2 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
root@ip-10-105-238-214:/opt/minitwit# git reset origin/master --hard
HEAD is now at 27eeee9 Merge pull request #6 from marcellodesales/hotfix/hostfix/fix-bug-running-private-zone
```

* Verifying the version from the hotfix

```console
root@ip-10-105-238-214:/opt/minitwit# git log
commit 27eeee9596369efd1b1d2921e9698b8539f94284 (HEAD -> master, origin/master, origin/HEAD)
Merge: 4835d2b 8a11bf0
Author: Marcello DeSales <marcello.desales@viasat.com>
Date:   Thu Mar 9 17:42:58 2023 -0800

    Merge pull request #6 from marcellodesales/hotfix/hostfix/fix-bug-running-private-zone

    :bug: hotfix: remove additional logs for healthcheck

commit 8a11bf0b810c9418a24e672e7319e6040df8f809 (origin/hotfix/hostfix/fix-bug-running-private-zone, hotfix/hostfix/fix-bug-running-private-zone)
Author: Marcello DeSales <marcello.desales@viasat.com>
Date:   Thu Mar 9 09:04:42 2023 -0800

    :bug: hotfix: remove additional logs for healthcheck

commit 4835d2be3935190e73e51e4d6a7338aed4065bc8
Author: Marcello DeSales <marcello.desales@viasat.com>
Date:   Thu Mar 9 09:04:42 2023 -0800
```

## ☄️ Make sure everything is working and restart the server

* Status

```console
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo systemctl status minitwit.service
● minitwit.service - Minitwit server II
     Loaded: loaded (/etc/systemd/system/minitwit.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2023-03-10 01:44:01 UTC; 2s ago
   Main PID: 2769 (flask)
      Tasks: 1 (limit: 4618)
     Memory: 48.6M
     CGroup: /system.slice/minitwit.service
             └─2769 /usr/bin/python3 /usr/local/bin/flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload
```

* Server restarted ok...

```console
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo systemctl restart minitwit.service
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo systemctl status minitwit.service
● minitwit.service - Minitwit server II
     Loaded: loaded (/etc/systemd/system/minitwit.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2023-03-10 01:44:01 UTC; 2s ago
   Main PID: 2769 (flask)
      Tasks: 1 (limit: 4618)
     Memory: 48.6M
     CGroup: /system.slice/minitwit.service
             └─2769 /usr/bin/python3 /usr/local/bin/flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload

Mar 10 01:44:02 ip-10-105-238-214 flask[2769]: [2023-03-10 01:44:02,775] INFO in minitwit: db_type=mysql endpoint=mtdb.cwxg4mojlhdg.us-east-1.rds.amazonaws.com db=mtdb username=mtdbuser using_secret=Fal>
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]: [2023-03-10 01:44:02,827] INFO in config_service: Endpoints: ['/static/<path:filename>', '/', '/public', '/<username>', '/<username>/follow', '/<username>/>
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]:  * Serving Flask app 'minitwit.py'
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]:  * Debug mode: off
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]: WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]:  * Running on all addresses (0.0.0.0)
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]:  * Running on http://127.0.0.1:5000
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]:  * Running on http://10.105.238.214:5000
Mar 10 01:44:02 ip-10-105-238-214 flask[2769]: Press CTRL+C to quit
Mar 10 01:44:03 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:44:03] "GET /public HTTP/1.1" 200 -
```

* Updated the properties with the release information used by the app

```properties
# Minitwit configuration
# Ansible managed

DB_TYPE = "mysql"
DB_USER = "mtdbuser"
DB_PASSWORD = "m****d"
DB_NAME = "mtdb"
DB_ENDPOINT = "mtdb.cwx****g.us-east-1.rds.amazonaws.com"
BUILD_GIT_VERSION = "4835d2be3935190e73e51e4d6a7338aed4065bc8"
BUILD_GIT_REPO = "https://github.com/marcellodesales/minitwit.git"
BUILD_GIT_BRANCH = "master"
```

ubuntu@ip-10-105-238-214:/opt/minitwit$ git rev-parse HEAD
27eeee9596369efd1b1d2921e9698b8539f94284
ubuntu@ip-10-105-238-214:/opt/minitwit$ git branch
  feature/implement-admin-actuator-endpoints-better-logging
  feature/show-hostname-response-header-load-balancer-debug
  hotfix/hostfix/fix-bug-running-private-zone
* master

ubuntu@ip-10-105-238-214:/opt/minitwit$ vim /etc/minitwit.conf
ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo vim /etc/minitwit.conf

ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo cat /etc/minitwit.conf
# Minitwit configuration
# Ansible managed

DB_TYPE = "mysql"
DB_USER = "mtdbuser"
DB_PASSWORD = "mt****ord"
DB_NAME = "mtdb"
DB_ENDPOINT = "mtdb.c****dg.us-east-1.rds.amazonaws.com"
BUILD_GIT_VERSION = "27eeee9596369efd1b1d2921e9698b8539f94284"
BUILD_GIT_REPO = "https://github.com/marcellodesales/minitwit.git"
BUILD_GIT_BRANCH = "master"
```

ubuntu@ip-10-105-238-214:/opt/minitwit$ sudo systemctl status minitwit.service
● minitwit.service - Minitwit server II
     Loaded: loaded (/etc/systemd/system/minitwit.service; enabled; vendor preset: enabled)
     Active: active (running) since Fri 2023-03-10 01:44:01 UTC; 2min 12s ago
   Main PID: 2769 (flask)
      Tasks: 1 (limit: 4618)
     Memory: 48.6M
     CGroup: /system.slice/minitwit.service
             └─2769 /usr/bin/python3 /usr/local/bin/flask run --host=0.0.0.0 --with-threads --no-debugger --no-reload

Mar 10 01:45:45 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:45:45] "GET /public HTTP/1.1" 200 -
Mar 10 01:45:46 ip-10-105-238-214 flask[2769]: 10.105.238.106 - - [10/Mar/2023 01:45:46] "GET /public HTTP/1.1" 200 -
Mar 10 01:45:51 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:45:51] "GET /public HTTP/1.1" 200 -
Mar 10 01:45:52 ip-10-105-238-214 flask[2769]: 10.105.238.106 - - [10/Mar/2023 01:45:52] "GET /public HTTP/1.1" 200 -
Mar 10 01:45:57 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:45:57] "GET /public HTTP/1.1" 200 -
Mar 10 01:45:58 ip-10-105-238-214 flask[2769]: 10.105.238.106 - - [10/Mar/2023 01:45:58] "GET /public HTTP/1.1" 200 -
Mar 10 01:46:03 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:46:03] "GET /public HTTP/1.1" 200 -
Mar 10 01:46:04 ip-10-105-238-214 flask[2769]: 10.105.238.106 - - [10/Mar/2023 01:46:04] "GET /public HTTP/1.1" 200 -
Mar 10 01:46:09 ip-10-105-238-214 flask[2769]: 10.105.238.36 - - [10/Mar/2023 01:46:09] "GET /public HTTP/1.1" 200 -
Mar 10 01:46:10 ip-10-105-238-214 flask[2769]: 10.105.238.106 - - [10/Mar/2023 01:46:10] "GET /public HTTP/1.1" 200 -
```

# :cloud: Creating AMI and everything in AWS

* ami-0b139615754bfcfac from the fix above
* Latest version is 27eeee9

# ⚡ Testing Load Balancer traffic with nodes spread across public and private

>> **NOTE**: The public and private hostnames are being returned as they are in different zones

```console
☁️  aws-cli@2.9.15
☸️  kubectl@1.24.3 📛 kustomize@1.24.3 🎡 helm@3.10.2    🐳 docker@20.10.21-rd 🐙 docker-compose@v2.14.0
👮 marcellodesales
🏗  1.24.3+k3s1 🔐 rancher-desktop 🍱 default
~/dev/git.viasat.com/mdesales/minitwit on  hotfix/hostfix/fix-bug-running-private-zone 📅 03-09-2023 ⌚18:06:26
$ curl -i http://minitwit-lb-2040902394.us-east-1.elb.amazonaws.com/healthcheck/liveness
HTTP/1.1 200 OK
Date: Fri, 10 Mar 2023 02:06:30 GMT
Content-Type: text/plain
Content-Length: 2
Connection: keep-alive
Set-Cookie: AWSALB=Wj7Ao386NlfMZMz8cVC5Wd3VcvtxrRU7ZuUdCPl8CbvykBjqeHCnWrfBliykn4ICjub5iwpw8cK87oXjp7IyXnwZ610FNAAoMZuhq5lxtonGCgIY+lKobf8jBFj/; Expires=Fri, 17 Mar 2023 02:06:30 GMT; Path=/
Set-Cookie: AWSALBCORS=Wj7Ao386NlfMZMz8cVC5Wd3VcvtxrRU7ZuUdCPl8CbvykBjqeHCnWrfBliykn4ICjub5iwpw8cK87oXjp7IyXnwZ610FNAAoMZuhq5lxtonGCgIY+lKobf8jBFj/; Expires=Fri, 17 Mar 2023 02:06:30 GMT; Path=/; SameSite=None
Server: Werkzeug/2.2.3 Python/3.8.10
Host: ip-10-105-238-139.ec2.internal
X-Host-AZ: us-east-1a
X-App-Version: 27eeee9

Ok%

☁️  aws-cli@2.9.15
☸️  kubectl@1.24.3 📛 kustomize@1.24.3 🎡 helm@3.10.2    🐳 docker@20.10.21-rd 🐙 docker-compose@v2.14.0
👮 marcellodesales
🏗  1.24.3+k3s1 🔐 rancher-desktop 🍱 default
~/dev/git.viasat.com/mdesales/minitwit on  hotfix/hostfix/fix-bug-running-private-zone 📅 03-09-2023 ⌚18:06:30
$ curl -i http://minitwit-lb-2040902394.us-east-1.elb.amazonaws.com/healthcheck/liveness
HTTP/1.1 200 OK
Date: Fri, 10 Mar 2023 02:06:31 GMT
Content-Type: text/plain
Content-Length: 2
Connection: keep-alive
Set-Cookie: AWSALB=bvtR28nLZ3pgg6f4UQ/d75OO0yaP480sv1WKLbTTmU4rn6UoyOhFD+MnniaUs5BG5alHkvE7WEr+LzqeChWjX8Q7/LwUpokLgIrPfvefb28eWD/oeYwm1IhIWzOi; Expires=Fri, 17 Mar 2023 02:06:31 GMT; Path=/
Set-Cookie: AWSALBCORS=bvtR28nLZ3pgg6f4UQ/d75OO0yaP480sv1WKLbTTmU4rn6UoyOhFD+MnniaUs5BG5alHkvE7WEr+LzqeChWjX8Q7/LwUpokLgIrPfvefb28eWD/oeYwm1IhIWzOi; Expires=Fri, 17 Mar 2023 02:06:31 GMT; Path=/; SameSite=None
Server: Werkzeug/2.2.3 Python/3.8.10
Host: ip-10-105-238-214.ec2.internal
X-Host-AZ: us-east-1b
X-App-Version: 27eeee9

Ok%

☁️  aws-cli@2.9.15
☸️  kubectl@1.24.3 📛 kustomize@1.24.3 🎡 helm@3.10.2    🐳 docker@20.10.21-rd 🐙 docker-compose@v2.14.0
👮 marcellodesales
🏗  1.24.3+k3s1 🔐 rancher-desktop 🍱 default
~/dev/git.viasat.com/mdesales/minitwit on  hotfix/hostfix/fix-bug-running-private-zone 📅 03-09-2023 ⌚18:06:32
$ curl -i http://minitwit-lb-2040902394.us-east-1.elb.amazonaws.com/healthcheck/liveness
HTTP/1.1 200 OK
Date: Fri, 10 Mar 2023 02:06:33 GMT
Content-Type: text/plain
Content-Length: 2
Connection: keep-alive
Set-Cookie: AWSALB=XnEK437XvPf8FyzC54DZAmZe38Ucehr21kKBSHEp2pjMPTf1IutYpetJJBD4sZ+A0BIHDZlMlXFtGCoO6CMZu06PPkT7xLRk7wws08QKq56Dd4MwIxlI4frBY0GE; Expires=Fri, 17 Mar 2023 02:06:33 GMT; Path=/
Set-Cookie: AWSALBCORS=XnEK437XvPf8FyzC54DZAmZe38Ucehr21kKBSHEp2pjMPTf1IutYpetJJBD4sZ+A0BIHDZlMlXFtGCoO6CMZu06PPkT7xLRk7wws08QKq56Dd4MwIxlI4frBY0GE; Expires=Fri, 17 Mar 2023 02:06:33 GMT; Path=/; SameSite=None
Server: Werkzeug/2.2.3 Python/3.8.10
Host: ec2-52-21-148-181.compute-1.amazonaws.com
X-Host-AZ: us-east-1b
X-App-Version: 4835d2b

Ok%
```